### PR TITLE
Capitalize cameras in RobotMap tf

### DIFF
--- a/src/org/usfirst/frc5112/Robot2017V3/RobotMap.java
+++ b/src/org/usfirst/frc5112/Robot2017V3/RobotMap.java
@@ -73,8 +73,8 @@ public class RobotMap {
 		gyro.calibrate();
 		
 		//tf = new TransformationMap();
-		//tf.put("pegCamera", new Pose(new Point(0, inchesToMeters(16), 0), Quaternion.zero));
-		//tf.put("boilerCamera", "pegCamera", new Pose(new Point(0, inchesToMeters(-1.5), inchesToMeters(3)), new Quaternion(Math.PI/4, Vector3.i)));
+		//tf.put("PegCamera", new Pose(new Point(0, inchesToMeters(16), 0), Quaternion.zero));
+		//tf.put("BoilerCamera", "PegCamera", new Pose(new Point(0, inchesToMeters(-1.5), inchesToMeters(3)), new Quaternion(Math.PI/4, Vector3.i)));
 		//tf.put("Intake", new Pose(new Point(0, inchesToMeters(16), 0), Quaternion.zero));
 		//tf.put("GearHolster", new Pose(new Point(inchesToMeters(0.5), inchesToMeters(14.75), inchesToMeters(14)), Quaternion.zero));
 		//tf.put("Shooter", new Pose(new Point(inchesToMeters(-6.25), inchesToMeters(-9.75), inchesToMeters(11.25)), Quaternion.zero));


### PR DESCRIPTION
This will allow the transformation code in the TargetingSubsystem to run correctly. Also, the newest version of the CoordinateFrames library will throw a nice exception if an issue like this happens in the future.